### PR TITLE
Enable using browser history and update server dependencies

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,7 +4,7 @@ from whitenoise import WhiteNoise
 app = Flask(__name__)
 app.config.from_object('config')
 
-app.wsgi_app = WhiteNoise(app.wsgi_app, root='app/static/', prefix='static/')
+app.wsgi_app = WhiteNoise(app.wsgi_app, root='app/static/', prefix='/', index_file=True)
 
 # Helper funcs ----------------------------------------------------------------
 from antlr_plsql import plsql_grammar, ast as plsql_ast
@@ -47,7 +47,7 @@ def get_ast(code, start, parser_name):
     return None
 
 # Views -----------------------------------------------------------------------
-from flask import Flask, request,  url_for, redirect, jsonify, make_response
+from flask import Flask, request, url_for, redirect, jsonify, make_response, send_file
 import yaml
 
 
@@ -104,3 +104,8 @@ def ast_from_config():
         out[k] = [{'code': code, 'ast': json_ast} for code, json_ast in zipped]
         print(out)
     return jsonify(out)
+
+
+@app.errorhandler(404)
+def page_not_found(error):
+    return send_file('./static/index.html')

--- a/app/static/index.js
+++ b/app/static/index.js
@@ -12,6 +12,7 @@ const routes = [
 ]
 
 const router = new VueRouter({
+    mode: 'history',
     routes
 })
 

--- a/app/static/src/editor.vue
+++ b/app/static/src/editor.vue
@@ -3,7 +3,7 @@
     <pre id="editor1"></pre>
     <div class="scrollmargin"></div>
 
-    parser: 
+    parser:
     <select type="text"  v-model="grammarName" v-on:change="resetStartPoint">
         <option v-for="grammar in grammars" :key="grammar.name" :value="grammar.name">
             {{grammar.name}}
@@ -11,9 +11,7 @@
     </select>
 
     start: <input type="text" v-model="parserStart">
-    <br>
-    <button v-on:click="parseCode">Submit Code</button>
-    <button v-on:click="routeToCode">Save</button>
+    <button v-on:click="submit">Submit Code</button>
 
     <!-- NODE GRAPH -->
 
@@ -35,7 +33,7 @@ var graphs = require('./graphs.js')
 var request = require('superagent')
 
 var grammars = [
-    { 
+    {
         name: 'plsql',
         start: 'sql_script',
         show_parse: true
@@ -95,8 +93,8 @@ export default {
         crntGrammar () { return this.grammars.filter(({name}) => name == this.grammarName)[0]},
     },
     watch: {
-        codeData () { 
-            this.getAst() 
+        codeData () {
+            this.getAst()
         },
     },
     methods: {
@@ -141,6 +139,11 @@ export default {
 
         resetStartPoint () {
             this.parserStart = this.crntGrammar.start
+        },
+
+        submit () {
+            this.parseCode()
+            this.routeToCode()
         },
 
         setupEditor(editor) {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 gunicorn==19.7.1
 gevent==1.2.1
-Flask==0.12.1
-whitenoise==3.3.1
+Flask==1.0.2
+whitenoise==4.1
 PyYAML==3.12
 
 antlr4-python3-runtime==4.7.1


### PR DESCRIPTION
Now routes don't come after the hash of the index file in the static folder, instead just following the root of the subdomain.
Instead of manually saving to the URL to copy it, the URL updates automatically and is added to your browser history (without page reload).