### PR TITLE
[CP-4984] Update npm token

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ workflows:
           name: docker-build
           context: org-global
           git_tag_filter: '--match "[0-9]*.[0-9]*.[0-9]*"'
-          extra-docker-args: '--build-arg NPM_TOKEN=$NPM_TOKEN'
+          extra-docker-args: '--build-arg NPM_TOKEN=$NPM_TOKEN_INSTALL_PACKAGES_READ'
           dockerfile: Dockerfile
           docker-version: 20.10.2
           executor: datacamp-artifactory/buildkit
@@ -57,7 +57,7 @@ workflows:
           name: docker-build
           artifactory-url: artifactory-proxy-public.ops.datacamp.com
           context: org-global
-          extra-docker-args: "--build-arg NPM_TOKEN=$NPM_TOKEN"
+          extra-docker-args: "--build-arg NPM_TOKEN=$NPM_TOKEN_INSTALL_PACKAGES_READ"
           dockerfile: Dockerfile
           docker-version: 20.10.2
           executor: datacamp-artifactory/buildkit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,6 @@ workflows:
           git_tag_filter: '--match "[0-9]*.[0-9]*.[0-9]*"'
           extra-docker-args: '--build-arg NPM_TOKEN=$NPM_TOKEN_INSTALL_PACKAGES_READ'
           dockerfile: Dockerfile
-          docker-version: 20.10.2
           executor: datacamp-artifactory/buildkit
           requires:
             - queue
@@ -59,7 +58,6 @@ workflows:
           context: org-global
           extra-docker-args: "--build-arg NPM_TOKEN=$NPM_TOKEN_INSTALL_PACKAGES_READ"
           dockerfile: Dockerfile
-          docker-version: 20.10.2
           executor: datacamp-artifactory/buildkit
           filters:
             branches:


### PR DESCRIPTION
**Description and Technical Details**

Related to [CP-4984](https://datacamp.atlassian.net/browse/CP-4984)

- `NPM_TOKEN` updated to `NPM_TOKEN_INSTALL_PACKAGES_READ` (this repo does not need to publish packages to NPM from CircleCI jobs)

- Removed `docker-version` from the circle-ci yml file

[CP-4984]: https://datacamp.atlassian.net/browse/CP-4984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ